### PR TITLE
default core-client 코드 수정

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,15 +27,17 @@ const pluginDir = new java.io.File(
   com.xfl.msgbot.utils.SharedVar.Companion.getBotsPath(),
   `${scriptName}/plugins`,
 );
+
 if (!pluginDir.exists())
   new java.io.File(
     com.xfl.msgbot.utils.SharedVar.Companion.getBotsPath(),
     `${scriptName}/plugins`,
   ).mkdir();
+else
+  Array.from(pluginDir.listFiles()).forEach((file) =>
+    require(file.getAbsolutePath()),
+  );
 
-Array.from(pluginDir.listFiles()).forEach((file) =>
-  require(file.getAbsolutePath()),
-);
 
 const socket = new java.net.DatagramSocket();
 const address = java.net.InetAddress.getByName(config.address);


### PR DESCRIPTION
기본 코드로 컴파일 했을때 발생하는 에러 (플러그인 없는경우) 수정 `RuntimeError(111) TypeError: Cannot convert null to an object (111#14) at 111:14`

![1111](https://github.com/remote-kakao/core-client/assets/157221628/595461e3-10a0-40d2-b72d-e30393e8bc64)

